### PR TITLE
BugFix - Make input description auto scroll to cursor position when it is out of visible bounds

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
         <activity
             android:name=".ui.screens.MainActivity"
             android:exported="true"
+            android:windowSoftInputMode="adjustResize"
             android:theme="@style/Theme.MyApp.Splash">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/AddEditScreen.kt
+++ b/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/AddEditScreen.kt
@@ -266,7 +266,7 @@ fun AddEditScreen(
                 })
             }
         }
-    }) {contentPadding ->
+    }) { contentPadding ->
 
         val scrollState = rememberScrollState()
         var descriptionScrollOffset by remember { mutableIntStateOf(0) }

--- a/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/AddEditScreen.kt
+++ b/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/AddEditScreen.kt
@@ -54,6 +54,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusDirection
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
@@ -265,176 +266,166 @@ fun AddEditScreen(
                 })
             }
         }
-    }) {
+    }) {contentPadding ->
+
+        val scrollState = rememberScrollState()
+        var descriptionScrollOffset by remember { mutableIntStateOf(0) }
+        var contentSize by remember { mutableIntStateOf(0) }
+
         Box(
-            modifier = Modifier.padding(it)
+            modifier = Modifier
+                .padding(contentPadding)
+                .onGloballyPositioned {
+                    contentSize = it.size.height
+                }
         ) {
             Column(
                 modifier = Modifier
                     .fillMaxSize()
-                    .verticalScroll(rememberScrollState())
+                    .verticalScroll(scrollState)
             ) {
-                if (isNew) {
-                    if (photoUri.isNotEmpty()) {
-                        LazyRow {
-                            items(photoUri.size) {
-                                Box(
-                                    Modifier
-                                        .height(180.dp)
-                                        .width(180.dp)
-                                        .padding(4.dp)
-                                        .clip(RoundedCornerShape(8.dp))
-                                ) {
-                                    ZoomableAsyncImage(
-                                        modifier = Modifier.fillMaxSize(),
-                                        model = photoUri[it],
-                                        contentDescription = stringResource(R.string.image),
-                                        contentScale = ContentScale.Crop
-                                    )
-                                    FilledTonalIconButton(
-                                        modifier = Modifier.align(Alignment.TopEnd),
-                                        onClick = {
-                                            photoUri = photoUri.filterIndexed { index, _ -> index != it }
-                                        },
-                                        colors = IconButtonDefaults.filledTonalIconButtonColors(
-                                            containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(
-                                                alpha = 0.6f
-                                            )
-                                        )
+                Column(
+                    modifier = Modifier.onGloballyPositioned { layoutCoordinates ->
+                        descriptionScrollOffset = layoutCoordinates.size.height
+                    }
+                ) {
+                    if (isNew) {
+                        if (photoUri.isNotEmpty()) {
+                            LazyRow {
+                                items(photoUri.size) {
+                                    Box(
+                                        Modifier
+                                            .height(180.dp)
+                                            .width(180.dp)
+                                            .padding(4.dp)
+                                            .clip(RoundedCornerShape(8.dp))
                                     ) {
-                                        Icon(
-                                            imageVector = Icons.Outlined.Close,
-                                            contentDescription = stringResource(R.string.clear_image)
+                                        ZoomableAsyncImage(
+                                            modifier = Modifier.fillMaxSize(),
+                                            model = photoUri[it],
+                                            contentDescription = stringResource(R.string.image),
+                                            contentScale = ContentScale.Crop
                                         )
+                                        FilledTonalIconButton(
+                                            modifier = Modifier.align(Alignment.TopEnd),
+                                            onClick = {
+                                                photoUri = photoUri.filterIndexed { index, _ -> index != it }
+                                            },
+                                            colors = IconButtonDefaults.filledTonalIconButtonColors(
+                                                containerColor = MaterialTheme.colorScheme.secondaryContainer.copy(
+                                                    alpha = 0.6f
+                                                )
+                                            )
+                                        ) {
+                                            Icon(
+                                                imageVector = Icons.Outlined.Close,
+                                                contentDescription = stringResource(R.string.clear_image)
+                                            )
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                } else {
-                    Row(
-                        modifier = Modifier
-                            .horizontalScroll(rememberScrollState())
-                    ) {
-                        photoUri.forEach { uri ->
-                            ZoomableAsyncImage(
-                                modifier = Modifier
-                                    .height(180.dp)
-                                    .width(180.dp)
-                                    .padding(4.dp)
-                                    .clip(RoundedCornerShape(8.dp)),
-                                model = uri ?: "",
-                                contentDescription = stringResource(R.string.image),
-                                contentScale = ContentScale.Crop
-                            )
+                    } else {
+                        Row(
+                            modifier = Modifier
+                                .horizontalScroll(rememberScrollState())
+                        ) {
+                            photoUri.forEach { uri ->
+                                ZoomableAsyncImage(
+                                    modifier = Modifier
+                                        .height(180.dp)
+                                        .width(180.dp)
+                                        .padding(4.dp)
+                                        .clip(RoundedCornerShape(8.dp)),
+                                    model = uri ?: "",
+                                    contentDescription = stringResource(R.string.image),
+                                    contentScale = ContentScale.Crop
+                                )
+                            }
                         }
                     }
+
+                    TextField(
+                        modifier = Modifier.fillMaxWidth(), value = title, onValueChange = { newTitle ->
+                            if (isNew) {
+                                title = newTitle
+                                characterCount = title.length + description.length
+                            } else {
+                                addEditViewModel.updateTitle(newTitle)
+                            }
+                        }, placeholder = {
+                            Text(
+                                stringResource(R.string.title),
+                                fontSize = 24.sp,
+                                fontWeight = FontWeight.W700,
+                                color = Color.Gray,
+                                fontFamily = FontFamily(Font(R.font.poppins_medium))
+                            )
+                        },
+                        textStyle = TextStyle(
+                            fontSize = 24.sp,
+                            fontFamily = FontFamily(Font(R.font.poppins_medium))
+                        ),
+                        maxLines = Int.MAX_VALUE,
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = MaterialTheme.colorScheme.surface,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                            disabledContainerColor = MaterialTheme.colorScheme.surface,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            disabledIndicatorColor = Color.Transparent
+                        ),
+                        keyboardOptions = KeyboardOptions.Default.copy(
+                            capitalization = KeyboardCapitalization.Sentences,
+                            keyboardType = KeyboardType.Text,
+                            imeAction = ImeAction.Next
+                        ),
+                        keyboardActions = KeyboardActions(onNext = {
+                            focus.moveFocus(FocusDirection.Down)
+                        })
+                    )
+
+                    TextField(
+                        value = if (isNew) {
+                            "$currentDate, $currentTime   |  $characterCount characters"
+                        } else {
+                            "$formattedDateTime | $formattedCharacterCount"
+                        },
+                        onValueChange = { },
+                        modifier = Modifier.fillMaxWidth(),
+                        readOnly = true,
+                        textStyle = TextStyle(
+                            fontSize = 15.sp,
+                            fontFamily = FontFamily(Font(R.font.poppins_light))
+                        ),
+                        colors = TextFieldDefaults.colors(
+                            focusedContainerColor = MaterialTheme.colorScheme.surface,
+                            unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                            disabledContainerColor = MaterialTheme.colorScheme.surface,
+                            focusedIndicatorColor = Color.Transparent,
+                            unfocusedIndicatorColor = Color.Transparent,
+                            disabledIndicatorColor = Color.Transparent
+                        ),
+                        keyboardOptions = KeyboardOptions.Default.copy(
+                            keyboardType = KeyboardType.Text
+                        )
+                    )
                 }
 
-                TextField(
-                    modifier = Modifier.fillMaxWidth(), value = title, onValueChange = { newTitle ->
-                        if (isNew) {
-                            title = newTitle
-                            characterCount = title.length + description.length
-                        } else {
-                            addEditViewModel.updateTitle(newTitle)
-                        }
-                    }, placeholder = {
-                        Text(
-                            stringResource(R.string.title),
-                            fontSize = 24.sp,
-                            fontWeight = FontWeight.W700,
-                            color = Color.Gray,
-                            fontFamily = FontFamily(Font(R.font.poppins_medium))
-                        )
-                    },
-                    textStyle = TextStyle(
-                        fontSize = 24.sp,
-                        fontFamily = FontFamily(Font(R.font.poppins_medium))
-                    ),
-                    maxLines = Int.MAX_VALUE,
-                    colors = TextFieldDefaults.colors(
-                        focusedContainerColor = MaterialTheme.colorScheme.surface,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-                        disabledContainerColor = MaterialTheme.colorScheme.surface,
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent,
-                        disabledIndicatorColor = Color.Transparent
-                    ),
-                    keyboardOptions = KeyboardOptions.Default.copy(
-                        capitalization = KeyboardCapitalization.Sentences,
-                        keyboardType = KeyboardType.Text,
-                        imeAction = ImeAction.Next
-                    ),
-                    keyboardActions = KeyboardActions(onNext = {
-                        focus.moveFocus(FocusDirection.Down)
-                    })
-                )
-
-                TextField(
-                    value = if (isNew) {
-                        "$currentDate, $currentTime   |  $characterCount characters"
-                    } else {
-                        "$formattedDateTime | $formattedCharacterCount"
-                    },
-                    onValueChange = { },
-                    modifier = Modifier.fillMaxWidth(),
-                    readOnly = true,
-                    textStyle = TextStyle(
-                        fontSize = 15.sp,
-                        fontFamily = FontFamily(Font(R.font.poppins_light))
-                    ),
-                    colors = TextFieldDefaults.colors(
-                        focusedContainerColor = MaterialTheme.colorScheme.surface,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-                        disabledContainerColor = MaterialTheme.colorScheme.surface,
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent,
-                        disabledIndicatorColor = Color.Transparent
-                    ),
-                    keyboardOptions = KeyboardOptions.Default.copy(
-                        keyboardType = KeyboardType.Text
-                    )
-                )
-
-                TextField(
-                    modifier = Modifier.fillMaxSize(),
-                    value = description,
-                    onValueChange = { newDescription ->
+                DescriptionTextField(
+                    scrollOffset = descriptionScrollOffset,
+                    contentSize = contentSize,
+                    description = description,
+                    parentScrollState = scrollState,
+                    onDescriptionChange = { newDescription ->
                         if (isNew) {
                             description = newDescription
                             characterCount = title.length + description.length
                         } else {
                             addEditViewModel.updateDescription(newDescription)
                         }
-                    },
-                    placeholder = {
-                        Text(
-                            stringResource(R.string.notes),
-                            fontSize = 20.sp,
-                            fontWeight = FontWeight.W500,
-                            color = Color.Gray,
-                            fontFamily = FontFamily(Font(R.font.poppins_light))
-                        )
-                    },
-                    textStyle = TextStyle(
-                        fontSize = 18.sp,
-                        fontFamily = FontFamily(Font(R.font.poppins_light))
-                    ),
-                    colors = TextFieldDefaults.colors(
-                        focusedContainerColor = MaterialTheme.colorScheme.surface,
-                        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-                        disabledContainerColor = MaterialTheme.colorScheme.surface,
-                        focusedIndicatorColor = Color.Transparent,
-                        unfocusedIndicatorColor = Color.Transparent,
-                        disabledIndicatorColor = Color.Transparent
-                    ),
-                    keyboardOptions = KeyboardOptions.Default.copy(
-                        capitalization = KeyboardCapitalization.Sentences,
-                        keyboardType = KeyboardType.Text
-                    ),
-                    maxLines = Int.MAX_VALUE
-
+                    }
                 )
             }
         }

--- a/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/DescriptionTextField.kt
+++ b/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/DescriptionTextField.kt
@@ -97,11 +97,11 @@ fun DescriptionTextField(
         },
         textStyle = TextStyle(
             fontSize = 18.sp,
-            fontFamily = FontFamily(Font(R.font.poppins_light)),
+            fontFamily = FontFamily(Font(R.font.poppins_light))
         ),
         keyboardOptions = KeyboardOptions.Default.copy(
             capitalization = KeyboardCapitalization.Sentences,
-            keyboardType = KeyboardType.Text,
+            keyboardType = KeyboardType.Text
         ),
         decorationBox = @Composable { innerTextField ->
             TextFieldDefaults.DecorationBox(
@@ -126,7 +126,7 @@ fun DescriptionTextField(
                     disabledContainerColor = MaterialTheme.colorScheme.surface,
                     focusedIndicatorColor = Color.Transparent,
                     unfocusedIndicatorColor = Color.Transparent,
-                    disabledIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent
                 )
             )
         }

--- a/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/DescriptionTextField.kt
+++ b/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/DescriptionTextField.kt
@@ -1,0 +1,134 @@
+package com.aritra.notify.ui.screens.notes.addEditScreen
+
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.gestures.animateScrollBy
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.Font
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.sp
+import com.aritra.notify.R
+import kotlinx.coroutines.launch
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DescriptionTextField(
+    modifier: Modifier = Modifier,
+    scrollOffset: Int,
+    contentSize: Int,
+    description: String,
+    parentScrollState: ScrollState,
+    onDescriptionChange: (String) -> Unit,
+) {
+    var descriptionFieldValue by remember {
+        mutableStateOf(TextFieldValue(description))
+    }
+    remember(description) {
+        descriptionFieldValue = descriptionFieldValue.copy(text = description)
+        Any()
+    }
+    var descriptionLayoutResult by remember { mutableStateOf<TextLayoutResult?>(null) }
+    val lineNumberAtCursor by remember {
+        derivedStateOf {
+            descriptionLayoutResult?.getLineForOffset(descriptionFieldValue.selection.start)
+        }
+    }
+    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(key1 = descriptionFieldValue.text) {
+        scope.launch {
+            val cursorLineNumber = lineNumberAtCursor ?: 0
+            val firstVisibleLinePosition = (parentScrollState.value - scrollOffset).toFloat()
+            val lastVisibleLinePosition = (parentScrollState.value + contentSize - scrollOffset).toFloat()
+            val firstVisibleLine = descriptionLayoutResult?.getLineForVerticalPosition(firstVisibleLinePosition) ?: 0
+            val lastLineVisible = descriptionLayoutResult?.getLineForVerticalPosition(lastVisibleLinePosition).let {
+                ((it ?: 0) - 1).coerceAtLeast(0) // decrement by 1 to get last completely visible line
+            }
+
+            if (cursorLineNumber < firstVisibleLine) {
+                val cursorLineTop = descriptionLayoutResult?.getLineTop(cursorLineNumber) ?: 0f
+                val firstLineTop = descriptionLayoutResult?.getLineTop(firstVisibleLine) ?: 0f
+                val diff = cursorLineTop - firstLineTop
+                parentScrollState.animateScrollBy(diff, spring(stiffness = Spring.StiffnessMediumLow))
+            } else if (cursorLineNumber >= lastLineVisible) {
+                val cursorLineBottom = descriptionLayoutResult?.getLineBottom(cursorLineNumber) ?: 0f
+                val lastLineTop = descriptionLayoutResult?.getLineTop(lastLineVisible) ?: 0f
+                val diff = cursorLineBottom - lastLineTop
+                parentScrollState.animateScrollBy(diff, spring(stiffness = Spring.StiffnessMediumLow))
+            }
+        }
+    }
+
+    BasicTextField(
+        modifier = modifier.fillMaxSize(),
+        value = descriptionFieldValue,
+        onValueChange = { newDescription ->
+            descriptionFieldValue = newDescription
+            onDescriptionChange(newDescription.text)
+        },
+        onTextLayout = {
+            descriptionLayoutResult = it
+        },
+        textStyle = TextStyle(
+            fontSize = 18.sp,
+            fontFamily = FontFamily(Font(R.font.poppins_light)),
+        ),
+        keyboardOptions = KeyboardOptions.Default.copy(
+            capitalization = KeyboardCapitalization.Sentences,
+            keyboardType = KeyboardType.Text,
+        ),
+        decorationBox = @Composable { innerTextField ->
+            TextFieldDefaults.DecorationBox(
+                value = descriptionFieldValue.text,
+                visualTransformation = VisualTransformation.None,
+                innerTextField = innerTextField,
+                placeholder = {
+                    Text(
+                        stringResource(R.string.notes),
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.W500,
+                        color = Color.Gray,
+                        fontFamily = FontFamily(Font(R.font.poppins_light))
+                    )
+                },
+                singleLine = false,
+                enabled = true,
+                interactionSource = remember { MutableInteractionSource() },
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = MaterialTheme.colorScheme.surface,
+                    unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                    disabledContainerColor = MaterialTheme.colorScheme.surface,
+                    focusedIndicatorColor = Color.Transparent,
+                    unfocusedIndicatorColor = Color.Transparent,
+                    disabledIndicatorColor = Color.Transparent,
+                )
+            )
+        }
+    )
+}


### PR DESCRIPTION
## Fixes #91 

The approach is to check the current cursor line number: If :-
1. cursor line number is above first visible line number -> scroll up to cursor position
2. cursor line number is below last visible line number -> scroll down to cursor position
3. else cursor is already in visible bounds of first and last visible line -> scroll not required 

There is some maths involved to find cursor position, first visible line, last visible line.
1. Cursor position -> we get this using [TextLayoutResult.getLineForOffset()](https://developer.android.com/reference/kotlin/androidx/compose/ui/text/TextLayoutResult#getLineForOffset(kotlin.Int)) and pass the 
2. firstVisibleLineNumber -> currentScrollValue of parent scrollable layout - scrollOffset. Here scrollOffset is the height of the composable above description textField.
3. lastVisibleLineNumber -> currentScrollValue of parent scrollable layout + contentSize - scrollOffset. Here content size is the height of scrollable parent composable, scrollOffset is same as before.

Final Result:

![auto_scroll (1)](https://github.com/aritra-tech/Notify/assets/51832211/72f1e323-fd58-4083-bb8b-3c87e35373f4)
