### PR TITLE
#161 Clickable Animation Issues in Bottom Navigation Item

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -7,7 +7,7 @@
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="corretto-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/app/src/main/java/com/aritra/notify/navigation/NotifyApp.kt
+++ b/app/src/main/java/com/aritra/notify/navigation/NotifyApp.kt
@@ -189,7 +189,6 @@ fun BottomNavigationBar(
                                 launchSingleTop = true
                             }
                         }
-
                     }
                 )
             }

--- a/app/src/main/java/com/aritra/notify/navigation/NotifyApp.kt
+++ b/app/src/main/java/com/aritra/notify/navigation/NotifyApp.kt
@@ -182,10 +182,14 @@ fun BottomNavigationBar(
                     },
                     selected = backStackEntry.value?.destination?.route == item.route,
                     onClick = {
-                        navController.navigate(item.route) {
-                            popUpTo(navController.graph.startDestinationId)
-                            launchSingleTop = true
+                        val currentDestination = navController.currentBackStackEntry?.destination?.route
+                        if (item.route != currentDestination) {
+                            navController.navigate(item.route) {
+                                popUpTo(navController.graph.startDestinationId)
+                                launchSingleTop = true
+                            }
                         }
+
                     }
                 )
             }


### PR DESCRIPTION
The main issue is that when clicking the right-side bottom navigation item, both the enter and exit animations are consistently triggered. Because when we click nav item ,the same screen/ route is triggered repeatedly.

We need to make sure that whether the current location/route matches the destination where we want to navigate.if they are not same we obviously navigate to the route. Otherwise we don't navigate to the route where we already in.

So i just check the current destination and bottom navigation item's route. It's solved the above issue.


<img width="758" alt="animation issues" src="https://github.com/aritra-tech/Notify/assets/54904545/2ca09639-eea8-48d3-9280-70abe754d587">

[bottom_navigation_issues.webm](https://github.com/aritra-tech/Notify/assets/54904545/7762730d-5d81-4d8f-93a0-387064fca502)
