### PR TITLE
changes-to-make-textedit-focused-in-case-of-new-note

### DIFF
--- a/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/AddEditScreen.kt
+++ b/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/AddEditScreen.kt
@@ -513,6 +513,7 @@ fun AddEditScreen(
                     contentSize = contentSize,
                     description = description,
                     parentScrollState = scrollState,
+                    isNewNote = isNew,
                     onDescriptionChange = { newDescription ->
                         if (isNew) {
                             description = newDescription

--- a/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/DescriptionTextField.kt
+++ b/app/src/main/java/com/aritra/notify/ui/screens/notes/addEditScreen/DescriptionTextField.kt
@@ -21,9 +21,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.res.stringResource
+    import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
@@ -45,8 +47,17 @@ fun DescriptionTextField(
     contentSize: Int,
     description: String,
     parentScrollState: ScrollState,
+    isNewNote:Boolean = false,
     onDescriptionChange: (String) -> Unit,
 ) {
+    val focusRequester = remember {
+        FocusRequester()
+    }
+    LaunchedEffect(Unit){
+        if (isNewNote) {
+            focusRequester.requestFocus()
+        }
+    }
     var descriptionFieldValue by remember {
         mutableStateOf(TextFieldValue(description))
     }
@@ -89,7 +100,8 @@ fun DescriptionTextField(
     val interactionSource = remember { MutableInteractionSource() }
 
     BasicTextField(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize()
+            .focusRequester(focusRequester),
         value = descriptionFieldValue,
         onValueChange = { newDescription ->
             descriptionFieldValue = newDescription


### PR DESCRIPTION
I've made the textedit focusable in case of adding new notes and when opening existing notes, this won't be the case. Have taken inspiration for this behaviour from IOS' notes application