### PR TITLE
[bugFix/alarmManager]

### DIFF
--- a/app/src/main/java/com/aritra/notify/services/alarm/AlarmSchedulerImpl.kt
+++ b/app/src/main/java/com/aritra/notify/services/alarm/AlarmSchedulerImpl.kt
@@ -42,7 +42,9 @@ class AlarmSchedulerImpl @Inject constructor(private val context: Context) : Ala
             if (alarmManager.canScheduleExactAlarms()) {
                 // NO OP for now
             } else {
-                context.startActivity(Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM))
+                val intent = Intent(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM)
+                    .apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+                context.startActivity(intent)
             }
         } else {
             // NO OP for now


### PR DESCRIPTION
Don't crash on SDK >= 31 devices when launching ACTION_REQUEST_SCHEDULE_EXACT_ALARM

....

It seems like the app could probably be re-engineered to not need an alarm manager at all, but anyway this prevents the app from crashing on launch (for new users or users who haven't given that permission to Notify yet)